### PR TITLE
feat: add optimized serde support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
   RUSTFLAGS: -D warnings
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
 
 jobs:
   rust-build:
@@ -38,11 +39,14 @@ jobs:
       - name: Rustfmt
         run: cargo fmt -- --check
 
-      - name: Clippy
-        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Clippy (Default features)
+        run: cargo clippy --locked --all-targets
+
+      - name: Clippy (All features)
+        run: cargo clippy --locked --all-targets --all-features
 
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --all-targets --all-features
 
       - name: Tests
-        run: cargo test --all-targets
+        run: cargo test --all-targets --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +58,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -119,25 +138,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -145,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -217,6 +235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,12 +268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,21 +284,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -317,26 +324,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "mimi_content"
 version = "0.1.0"
 dependencies = [
+ "ciborium",
  "criterion",
  "hex",
- "mimi_content 0.1.0 (git+https://github.com/phnx-im/mimi-content.git?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452)",
  "minicbor",
  "minicbor-derive",
+ "minicbor-serde",
  "num_enum",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "mimi_content"
-version = "0.1.0"
-source = "git+https://github.com/phnx-im/mimi-content.git?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452#9189ef0b350576e6edd130e43d281c8eb9bfe452"
-dependencies = [
- "ciborium",
- "hex",
  "serde",
  "serde_bytes",
- "serde_list",
  "sha2",
  "thiserror",
 ]
@@ -359,6 +355,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80047f75e28e3b38f6ab2ec3c2c7669f6b411fa6f8424e1a90a3fd784b19a3f4"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -403,6 +409,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "plotters"
@@ -577,24 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_list"
-version = "1.1.0"
-source = "git+https://github.com/phnx-im/mimi-content.git?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452#9189ef0b350576e6edd130e43d281c8eb9bfe452"
-dependencies = [
- "serde",
- "serde_list_macros",
-]
-
-[[package]]
-name = "serde_list_macros"
-version = "0.1.0"
-source = "git+https://github.com/phnx-im/mimi-content.git?rev=9189ef0b350576e6edd130e43d281c8eb9bfe452#9189ef0b350576e6edd130e43d281c8eb9bfe452"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +602,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
@@ -760,6 +764,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +787,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,24 @@ version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 
+[features]
+serde = ["dep:serde", "serde_bytes"]
+
 [dependencies]
 minicbor = { version = "2.2.1", features = ["std", "derive"] }
 minicbor-derive = { version = "0.19" }
 sha2 = "0.10.9"
 thiserror = "2.0.11"
 num_enum = "0.7.6"
+serde = { version = "1.0.228", optional = true }
+serde_bytes = { version = "0.11.19", optional = true }
 
 [[bench]]
 name = "codec"
 harness = false
 
 [dev-dependencies]
-criterion = "0.5.1"
-mimi_content_ciborium = { git = "https://github.com/phnx-im/mimi-content.git", rev = "9189ef0b350576e6edd130e43d281c8eb9bfe452", package = "mimi_content" }
+ciborium = "0.2.2"
+criterion = "0.8.2"
 hex = "0.4.3"
+minicbor-serde = { version = "0.6.2", features = ["std"] }

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::{collections::BTreeMap, hint::black_box, io::Cursor};
+use std::{collections::BTreeMap, hint::black_box};
 
 fn minicbor_mimi_content() -> mimi_content::MimiContent {
     use mimi_content::content_container::{
@@ -83,10 +83,7 @@ fn large_mimi_content() -> mimi_content::MimiContent {
 
 fn criterion_benchmark(c: &mut Criterion) {
     let content = minicbor_mimi_content();
-    let minicbor_content_bytes = content.serialize().unwrap();
-
-    let mut ciborium_multipart_bytes = Vec::new();
-    ciborium::into_writer(&content, &mut ciborium_multipart_bytes).unwrap();
+    let content_bytes = content.serialize().unwrap();
 
     let mut encode = c.benchmark_group("encode");
     encode.bench_function("minicbor-encode", |b| {
@@ -94,11 +91,13 @@ fn criterion_benchmark(c: &mut Criterion) {
             black_box(content.serialize().unwrap());
         });
     });
+    #[cfg(feature = "serde")]
     encode.bench_function("minicbor-serde-encode", |b| {
         b.iter(|| {
             black_box(minicbor_serde::to_vec(&content).unwrap());
         });
     });
+    #[cfg(feature = "serde")]
     encode.bench_function("ciborium-encode", |b| {
         b.iter(|| {
             let mut ciborium_bytes = Vec::new();
@@ -109,17 +108,17 @@ fn criterion_benchmark(c: &mut Criterion) {
     encode.finish();
 
     let large_content = large_mimi_content();
-    let large_minicbor_bytes = large_content.serialize().unwrap();
-    let mut large_ciborium_bytes = Vec::new();
-    ciborium::into_writer(&large_content, &mut large_ciborium_bytes).unwrap();
+    let large_content_bytes = large_content.serialize().unwrap();
 
     let mut encode_large = c.benchmark_group("encode-large");
     encode_large.bench_function("minicbor-encode", |b| {
         b.iter(|| black_box(large_content.serialize().unwrap()));
     });
+    #[cfg(feature = "serde")]
     encode_large.bench_function("minicbor-serde-encode", |b| {
         b.iter(|| black_box(minicbor_serde::to_vec(&large_content).unwrap()));
     });
+    #[cfg(feature = "serde")]
     encode_large.bench_function("ciborium-encode", |b| {
         b.iter(|| {
             let mut bytes = Vec::new();
@@ -131,21 +130,25 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let mut decode_large = c.benchmark_group("decode-large");
     decode_large.bench_function("minicbor-decode", |b| {
-        b.iter(|| black_box(mimi_content::MimiContent::deserialize(&large_minicbor_bytes).unwrap()));
+        b.iter(|| black_box(mimi_content::MimiContent::deserialize(&large_content_bytes).unwrap()));
     });
+    #[cfg(feature = "serde")]
     decode_large.bench_function("minicbor-serde-decode", |b| {
         b.iter(|| {
             black_box(
-                minicbor_serde::from_slice::<mimi_content::MimiContent>(&large_minicbor_bytes)
+                minicbor_serde::from_slice::<mimi_content::MimiContent>(&large_content_bytes)
                     .unwrap(),
             )
         });
     });
+    #[cfg(feature = "serde")]
     decode_large.bench_function("ciborium-decode", |b| {
         b.iter(|| {
+            use std::io::Cursor;
+
             black_box(
                 ciborium::from_reader::<mimi_content::MimiContent, _>(Cursor::new(
-                    &large_ciborium_bytes,
+                    &large_content_bytes,
                 ))
                 .unwrap(),
             )
@@ -156,24 +159,25 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut decode = c.benchmark_group("decode");
     decode.bench_function("minicbor-decode", |b| {
         b.iter(|| {
-            black_box(mimi_content::MimiContent::deserialize(&minicbor_content_bytes).unwrap());
+            black_box(mimi_content::MimiContent::deserialize(&content_bytes).unwrap());
         });
     });
+    #[cfg(feature = "serde")]
     decode.bench_function("minicbor-serde-decode", |b| {
         b.iter(|| {
             black_box(
-                minicbor_serde::from_slice::<mimi_content::MimiContent>(&minicbor_content_bytes)
-                    .unwrap(),
+                minicbor_serde::from_slice::<mimi_content::MimiContent>(&content_bytes).unwrap(),
             );
         });
     });
+    #[cfg(feature = "serde")]
     decode.bench_function("ciborium-decode", |b| {
         b.iter(|| {
+            use std::io::Cursor;
+
             black_box(
-                ciborium::from_reader::<mimi_content::MimiContent, _>(Cursor::new(
-                    &ciborium_multipart_bytes,
-                ))
-                .unwrap(),
+                ciborium::from_reader::<mimi_content::MimiContent, _>(Cursor::new(&content_bytes))
+                    .unwrap(),
             );
         })
     });

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::collections::BTreeMap;
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::{collections::BTreeMap, hint::black_box, io::Cursor};
 
 fn minicbor_mimi_content() -> mimi_content::MimiContent {
     use mimi_content::content_container::{
@@ -53,100 +53,131 @@ fn minicbor_mimi_content() -> mimi_content::MimiContent {
     }
 }
 
-fn ciborium_mimi_content() -> mimi_content_ciborium::MimiContent {
-    use mimi_content_ciborium::{
-        content_container::{
-            Disposition, ExtensionName, MimiContent, NestedPart, NestedPartContent, PartSemantics,
-        },
-        ByteBuf,
-    };
+fn large_mimi_content() -> mimi_content::MimiContent {
+    use mimi_content::content_container::{Disposition, MimiContent, NestedPart, PartSemantics};
 
-    let extensions_alice = || {
-        let mut extensions = BTreeMap::new();
-        extensions.insert(
-            ExtensionName::Number(1.into()),
-            "mimi://example.com/u/alice-smith".into(),
-        );
-        extensions.insert(
-            ExtensionName::Number(2.into()),
-            "mimi://example.com/r/engineering_team".into(),
-        );
-
-        extensions
-    };
-
-    MimiContent {
-        salt: ByteBuf::from(hex::decode("261c953e178af653fe3d42641b91d814").unwrap()),
-        replaces: None,
-        topic_id: ByteBuf::from(b""),
-        expires: None,
-        in_reply_to: None,
-        extensions: extensions_alice(),
-        nested_part: NestedPart {
+    let parts = (0..13_000)
+        .map(|i| NestedPart::SinglePart {
             disposition: Disposition::Render,
             language: "".to_owned(),
-            part: NestedPartContent::MultiPart {
-                part_semantics: PartSemantics::ChooseOne,
-                parts: vec![
-                    NestedPart {
-                        disposition: Disposition::Render,
-                        language: "".to_owned(),
-                        part: NestedPartContent::SinglePart {
-                            content_type: "text/markdown;variant=GFM-MIMI".to_owned(),
-                            content: ByteBuf::from(b"# Welcome!"),
-                        },
-                    },
-                    NestedPart {
-                        disposition: Disposition::Render,
-                        language: "".to_owned(),
-                        part: NestedPartContent::SinglePart {
-                            content_type: "application/vnd.examplevendor-fancy-im-message"
-                                .to_owned(),
-                            content: hex::decode("dc861ebaa718fd7c3ca159f71a2001")
-                                .unwrap()
-                                .into(),
-                        },
-                    },
-                ],
-            },
+            content_type: "text/markdown;variant=GFM-MIMI".to_owned(),
+            content: format!("Message number {i}: hello world!").into_bytes(),
+        })
+        .collect();
+
+    MimiContent {
+        salt: hex::decode("261c953e178af653fe3d42641b91d814").unwrap(),
+        replaces: None,
+        topic_id: b"".to_vec(),
+        expires: None,
+        in_reply_to: None,
+        extensions: Default::default(),
+        nested_part: NestedPart::MultiPart {
+            disposition: Disposition::Render,
+            language: "".to_owned(),
+            part_semantics: PartSemantics::ChooseOne,
+            parts,
         },
     }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let minicbor_multipart = minicbor_mimi_content();
-    let minicbor_multipart_bytes = minicbor_multipart.serialize().unwrap();
+    let content = minicbor_mimi_content();
+    let minicbor_content_bytes = content.serialize().unwrap();
 
-    let ciborium_multipart = ciborium_mimi_content();
-    let ciborium_multipart_bytes = ciborium_multipart.serialize().unwrap();
+    let mut ciborium_multipart_bytes = Vec::new();
+    ciborium::into_writer(&content, &mut ciborium_multipart_bytes).unwrap();
 
-    let mut minicbor = c.benchmark_group("minicbor");
-    minicbor.bench_function("encode", |b| {
+    let mut encode = c.benchmark_group("encode");
+    encode.bench_function("minicbor-encode", |b| {
         b.iter(|| {
-            black_box(minicbor_multipart.serialize().unwrap());
+            black_box(content.serialize().unwrap());
         });
     });
-    minicbor.bench_function("decode", |b| {
+    encode.bench_function("minicbor-serde-encode", |b| {
         b.iter(|| {
-            black_box(mimi_content::MimiContent::deserialize(&minicbor_multipart_bytes).unwrap());
+            black_box(minicbor_serde::to_vec(&content).unwrap());
         });
     });
-    minicbor.finish();
-
-    let mut ciborium = c.benchmark_group("ciborium");
-    ciborium.bench_function("ciborium-encode", |b| {
+    encode.bench_function("ciborium-encode", |b| {
         b.iter(|| {
-            black_box(ciborium_multipart.serialize().unwrap());
+            let mut ciborium_bytes = Vec::new();
+            ciborium::into_writer(&content, &mut ciborium_bytes).unwrap();
+            black_box(ciborium_bytes);
         })
     });
+    encode.finish();
 
-    ciborium.bench_function("ciborium-decode", |b| {
+    let large_content = large_mimi_content();
+    let large_minicbor_bytes = large_content.serialize().unwrap();
+    let mut large_ciborium_bytes = Vec::new();
+    ciborium::into_writer(&large_content, &mut large_ciborium_bytes).unwrap();
+
+    let mut encode_large = c.benchmark_group("encode-large");
+    encode_large.bench_function("minicbor-encode", |b| {
+        b.iter(|| black_box(large_content.serialize().unwrap()));
+    });
+    encode_large.bench_function("minicbor-serde-encode", |b| {
+        b.iter(|| black_box(minicbor_serde::to_vec(&large_content).unwrap()));
+    });
+    encode_large.bench_function("ciborium-encode", |b| {
+        b.iter(|| {
+            let mut bytes = Vec::new();
+            ciborium::into_writer(&large_content, &mut bytes).unwrap();
+            black_box(bytes);
+        });
+    });
+    encode_large.finish();
+
+    let mut decode_large = c.benchmark_group("decode-large");
+    decode_large.bench_function("minicbor-decode", |b| {
+        b.iter(|| black_box(mimi_content::MimiContent::deserialize(&large_minicbor_bytes).unwrap()));
+    });
+    decode_large.bench_function("minicbor-serde-decode", |b| {
         b.iter(|| {
             black_box(
-                mimi_content_ciborium::MimiContent::deserialize(&ciborium_multipart_bytes).unwrap(),
+                minicbor_serde::from_slice::<mimi_content::MimiContent>(&large_minicbor_bytes)
+                    .unwrap(),
+            )
+        });
+    });
+    decode_large.bench_function("ciborium-decode", |b| {
+        b.iter(|| {
+            black_box(
+                ciborium::from_reader::<mimi_content::MimiContent, _>(Cursor::new(
+                    &large_ciborium_bytes,
+                ))
+                .unwrap(),
+            )
+        });
+    });
+    decode_large.finish();
+
+    let mut decode = c.benchmark_group("decode");
+    decode.bench_function("minicbor-decode", |b| {
+        b.iter(|| {
+            black_box(mimi_content::MimiContent::deserialize(&minicbor_content_bytes).unwrap());
+        });
+    });
+    decode.bench_function("minicbor-serde-decode", |b| {
+        b.iter(|| {
+            black_box(
+                minicbor_serde::from_slice::<mimi_content::MimiContent>(&minicbor_content_bytes)
+                    .unwrap(),
+            );
+        });
+    });
+    decode.bench_function("ciborium-decode", |b| {
+        b.iter(|| {
+            black_box(
+                ciborium::from_reader::<mimi_content::MimiContent, _>(Cursor::new(
+                    &ciborium_multipart_bytes,
+                ))
+                .unwrap(),
             );
         })
     });
+    decode.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/content_container.rs
+++ b/src/content_container.rs
@@ -471,13 +471,6 @@ pub enum Disposition {
     Custom(u8),
 }
 
-// #[expect(clippy::derivable_impls, reason = "Does not work with num_enum derive")]
-// impl Default for Disposition {
-//     fn default() -> Self {
-//         Self::Unspecified
-//     }
-// }
-
 impl_encode_decode_num_enum!(Disposition, u8);
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, IntoPrimitive, FromPrimitive)]
@@ -1393,6 +1386,51 @@ mod tests {
         );
 
         assert_eq!(hex::encode(result), hex::encode(target));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn multipart_minicbor_serde_compat() {
+        let value = MimiContent {
+            salt: hex::decode("261c953e178af653fe3d42641b91d814").unwrap(),
+            replaces: None,
+            topic_id: b"".to_vec(),
+            expires: None,
+            in_reply_to: None,
+            extensions: extensions_alice(),
+            nested_part: NestedPart::MultiPart {
+                disposition: Disposition::Render,
+                language: "".to_owned(),
+                part_semantics: PartSemantics::ChooseOne,
+                parts: vec![
+                    NestedPart::SinglePart {
+                        disposition: Disposition::Render,
+                        language: "".to_owned(),
+                        content_type: "text/markdown;variant=GFM-MIMI".to_owned(),
+                        content: b"# Welcome!".to_vec(),
+                    },
+                    NestedPart::SinglePart {
+                        disposition: Disposition::Render,
+                        language: "".to_owned(),
+                        content_type: "application/vnd.examplevendor-fancy-im-message".to_owned(),
+                        content: hex::decode("dc861ebaa718fd7c3ca159f71a2001").unwrap(),
+                    },
+                ],
+            },
+        };
+
+        let minicbor_bytes = value.serialize().unwrap();
+        let minicbor_serde_bytes = minicbor_serde::to_vec(&value).unwrap();
+
+        assert_eq!(
+            hex::encode(&minicbor_bytes),
+            hex::encode(&minicbor_serde_bytes)
+        );
+
+        let minicbor_content: MimiContent = MimiContent::deserialize(&minicbor_bytes).unwrap();
+        let minicbor_serde_content: MimiContent =
+            minicbor_serde::from_slice(&minicbor_serde_bytes).unwrap();
+        assert_eq!(minicbor_content, minicbor_serde_content);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2024 Phoenix R&D GmbH <hello@phnx.im>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#[deny(warnings)]
 pub mod cbor;
 pub mod content_container;
 mod message_status;
+#[cfg(feature = "serde")]
+mod serde;
 pub(crate) mod util;
 
 pub use content_container::{Error, MimiContent, Result};

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::BTreeMap;
+
+use ::serde::{
+    de::{self, Visitor},
+    ser::SerializeSeq,
+    Deserialize, Serialize, Serializer,
+};
+
+use crate::{
+    cbor::Value,
+    content_container::{
+        Disposition, EncryptionAlgorithm, Expiration, ExtensionName, HashAlgorithm, MimiContent,
+        NestedPart, PartSemantics,
+    },
+};
+
+impl Serialize for Value {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Value::Bool(v) => v.serialize(serializer),
+            Value::Int(v) => v.serialize(serializer),
+            Value::Float(v) => v.serialize(serializer),
+            Value::Text(v) => v.serialize(serializer),
+            Value::Bytes(v) => v.serialize(serializer),
+            Value::Array(v) => v.serialize(serializer),
+            Value::Map(v) => v.serialize(serializer),
+            Value::Null => serializer.serialize_unit(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("any CBOR value")
+            }
+
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Value, E> {
+                Ok(Value::Bool(v))
+            }
+            fn visit_i8<E: de::Error>(self, v: i8) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_i16<E: de::Error>(self, v: i16) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_i32<E: de::Error>(self, v: i32) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Value, E> {
+                Ok(Value::Int(v))
+            }
+            fn visit_u8<E: de::Error>(self, v: u8) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_u16<E: de::Error>(self, v: u16) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_u32<E: de::Error>(self, v: u32) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Value, E> {
+                Ok(Value::Int(v as i64))
+            }
+            fn visit_f32<E: de::Error>(self, v: f32) -> Result<Value, E> {
+                Ok(Value::Float(v as f64))
+            }
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<Value, E> {
+                Ok(Value::Float(v))
+            }
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Value, E> {
+                Ok(Value::Text(v.to_string().into()))
+            }
+            fn visit_string<E: de::Error>(self, v: String) -> Result<Value, E> {
+                Ok(Value::Text(v.into()))
+            }
+            fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Value, E> {
+                Ok(Value::Bytes(v.to_vec()))
+            }
+            fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Value, E> {
+                Ok(Value::Bytes(v))
+            }
+            fn visit_unit<E: de::Error>(self) -> Result<Value, E> {
+                Ok(Value::Null)
+            }
+            fn visit_none<E: de::Error>(self) -> Result<Value, E> {
+                Ok(Value::Null)
+            }
+            fn visit_some<D: ::serde::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<Value, D::Error> {
+                Value::deserialize(deserializer)
+            }
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Value, A::Error> {
+                let mut arr = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(v) = seq.next_element()? {
+                    arr.push(v);
+                }
+                Ok(Value::Array(arr))
+            }
+            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Value, A::Error> {
+                let mut result = BTreeMap::new();
+                while let Some((k, v)) = map.next_entry()? {
+                    result.insert(k, v);
+                }
+                Ok(Value::Map(result))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+impl Serialize for ExtensionName {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ExtensionName::Text(s) => serializer.serialize_str(s),
+            ExtensionName::Number(n) => serializer.serialize_u64(*n),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionName {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ExtensionNameVisitor;
+
+        impl<'de> Visitor<'de> for ExtensionNameVisitor {
+            type Value = ExtensionName;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a string or unsigned integer")
+            }
+
+            fn visit_u8<E: de::Error>(self, v: u8) -> Result<ExtensionName, E> {
+                Ok(ExtensionName::Number(v as u64))
+            }
+            fn visit_u16<E: de::Error>(self, v: u16) -> Result<ExtensionName, E> {
+                Ok(ExtensionName::Number(v as u64))
+            }
+            fn visit_u32<E: de::Error>(self, v: u32) -> Result<ExtensionName, E> {
+                Ok(ExtensionName::Number(v as u64))
+            }
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<ExtensionName, E> {
+                Ok(ExtensionName::Number(v))
+            }
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<ExtensionName, E> {
+                Ok(ExtensionName::Text(v.to_owned()))
+            }
+            fn visit_string<E: de::Error>(self, v: String) -> Result<ExtensionName, E> {
+                Ok(ExtensionName::Text(v))
+            }
+        }
+
+        deserializer.deserialize_any(ExtensionNameVisitor)
+    }
+}
+
+impl Serialize for MimiContent {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(7))?;
+        seq.serialize_element(serde_bytes::Bytes::new(&self.salt))?;
+        seq.serialize_element(&self.replaces.as_deref().map(serde_bytes::Bytes::new))?;
+        seq.serialize_element(serde_bytes::Bytes::new(&self.topic_id))?;
+        seq.serialize_element(&self.expires)?;
+        seq.serialize_element(&self.in_reply_to.as_deref().map(serde_bytes::Bytes::new))?;
+        seq.serialize_element(&self.extensions)?;
+        seq.serialize_element(&self.nested_part)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MimiContent {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct MimiContentVisitor;
+
+        impl<'de> Visitor<'de> for MimiContentVisitor {
+            type Value = MimiContent;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a 7-element MIMI content array")
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<MimiContent, A::Error> {
+                let salt: serde_bytes::ByteBuf = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let replaces: Option<serde_bytes::ByteBuf> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let topic_id: serde_bytes::ByteBuf = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                let expires: Option<Expiration> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                let in_reply_to: Option<serde_bytes::ByteBuf> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                let extensions: BTreeMap<ExtensionName, Value> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(5, &self))?;
+                let nested_part: NestedPart = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(6, &self))?;
+                Ok(MimiContent {
+                    salt: salt.into_vec(),
+                    replaces: replaces.map(|b| b.into_vec()),
+                    topic_id: topic_id.into_vec(),
+                    expires,
+                    in_reply_to: in_reply_to.map(|b| b.into_vec()),
+                    extensions,
+                    nested_part,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(MimiContentVisitor)
+    }
+}
+
+impl Serialize for Expiration {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&self.relative)?;
+        seq.serialize_element(&self.time)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Expiration {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ExpirationVisitor;
+
+        impl<'de> Visitor<'de> for ExpirationVisitor {
+            type Value = Expiration;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a 2-element array [bool, u32]")
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Expiration, A::Error> {
+                let relative = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let time = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                Ok(Expiration { relative, time })
+            }
+        }
+
+        deserializer.deserialize_seq(ExpirationVisitor)
+    }
+}
+
+impl Serialize for NestedPart {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            NestedPart::NullPart {
+                disposition,
+                language,
+            } => {
+                let mut seq = serializer.serialize_seq(Some(3))?;
+                seq.serialize_element(disposition)?;
+                seq.serialize_element(language)?;
+                seq.serialize_element(&0u8)?;
+                seq.end()
+            }
+            NestedPart::SinglePart {
+                disposition,
+                language,
+                content_type,
+                content,
+            } => {
+                let mut seq = serializer.serialize_seq(Some(5))?;
+                seq.serialize_element(disposition)?;
+                seq.serialize_element(language)?;
+                seq.serialize_element(&1u8)?;
+                seq.serialize_element(content_type)?;
+                seq.serialize_element(serde_bytes::Bytes::new(content))?;
+                seq.end()
+            }
+            NestedPart::ExternalPart {
+                disposition,
+                language,
+                content_type,
+                url,
+                expires,
+                size,
+                enc_alg,
+                key,
+                nonce,
+                aad,
+                hash_alg,
+                content_hash,
+                description,
+                filename,
+            } => {
+                let mut seq = serializer.serialize_seq(Some(15))?;
+                seq.serialize_element(disposition)?;
+                seq.serialize_element(language)?;
+                seq.serialize_element(&2u8)?;
+                seq.serialize_element(content_type)?;
+                seq.serialize_element(url)?;
+                seq.serialize_element(expires)?;
+                seq.serialize_element(size)?;
+                seq.serialize_element(enc_alg)?;
+                seq.serialize_element(serde_bytes::Bytes::new(key))?;
+                seq.serialize_element(serde_bytes::Bytes::new(nonce))?;
+                seq.serialize_element(serde_bytes::Bytes::new(aad))?;
+                seq.serialize_element(hash_alg)?;
+                seq.serialize_element(serde_bytes::Bytes::new(content_hash))?;
+                seq.serialize_element(description)?;
+                seq.serialize_element(filename)?;
+                seq.end()
+            }
+            NestedPart::MultiPart {
+                disposition,
+                language,
+                part_semantics,
+                parts,
+            } => {
+                let mut seq = serializer.serialize_seq(Some(5))?;
+                seq.serialize_element(disposition)?;
+                seq.serialize_element(language)?;
+                seq.serialize_element(&3u8)?;
+                seq.serialize_element(part_semantics)?;
+                seq.serialize_element(parts)?;
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for NestedPart {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct NestedPartVisitor;
+
+        impl<'de> Visitor<'de> for NestedPartVisitor {
+            type Value = NestedPart;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a MIMI NestedPart array")
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<NestedPart, A::Error> {
+                let disposition: Disposition = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let language: String = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let discriminant: u8 = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                match discriminant {
+                    0 => Ok(NestedPart::NullPart {
+                        disposition,
+                        language,
+                    }),
+                    1 => {
+                        let content_type: String = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                        let content: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                        Ok(NestedPart::SinglePart {
+                            disposition,
+                            language,
+                            content_type,
+                            content: content.into_vec(),
+                        })
+                    }
+                    2 => {
+                        let content_type: String = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                        let url: String = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                        let expires: u32 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(5, &self))?;
+                        let size: u64 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(6, &self))?;
+                        let enc_alg: EncryptionAlgorithm = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(7, &self))?;
+                        let key: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(8, &self))?;
+                        let nonce: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(9, &self))?;
+                        let aad: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(10, &self))?;
+                        let hash_alg: HashAlgorithm = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(11, &self))?;
+                        let content_hash: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(12, &self))?;
+                        let description: String = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(13, &self))?;
+                        let filename: String = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(14, &self))?;
+                        Ok(NestedPart::ExternalPart {
+                            disposition,
+                            language,
+                            content_type,
+                            url,
+                            expires,
+                            size,
+                            enc_alg,
+                            key: key.into_vec(),
+                            nonce: nonce.into_vec(),
+                            aad: aad.into_vec(),
+                            hash_alg,
+                            content_hash: content_hash.into_vec(),
+                            description,
+                            filename,
+                        })
+                    }
+                    3 => {
+                        let part_semantics: PartSemantics = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                        let parts: Vec<NestedPart> = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                        Ok(NestedPart::MultiPart {
+                            disposition,
+                            language,
+                            part_semantics,
+                            parts,
+                        })
+                    }
+                    _ => Err(de::Error::custom(format!(
+                        "invalid discriminant {discriminant} for NestedPart"
+                    ))),
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(NestedPartVisitor)
+    }
+}
+
+macro_rules! impl_serde_num_enum {
+    ($ty:ty, $repr:ty) => {
+        impl ::serde::Serialize for $ty {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                let repr: $repr = (*self).into();
+                repr.serialize(serializer)
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                let value: $repr = Deserialize::deserialize(deserializer)?;
+                Ok(Self::from(value))
+            }
+        }
+    };
+}
+
+impl_serde_num_enum!(HashAlgorithm, u8);
+impl_serde_num_enum!(EncryptionAlgorithm, u16);
+impl_serde_num_enum!(Disposition, u8);
+impl_serde_num_enum!(PartSemantics, u8);


### PR DESCRIPTION
After merging #10 the derives for `Serialize` and `Deserialize` were removed. It can be beneficial to re-introduce them to help with migrations and/or use other serialisers than `minicbor`.